### PR TITLE
Bump Newtonsoft.Json from 11.0.2 to 13.0.3

### DIFF
--- a/src/TeamCitySharp/TeamCitySharp.csproj
+++ b/src/TeamCitySharp/TeamCitySharp.csproj
@@ -20,7 +20,7 @@
     <DefineConstants>NETCORE;NETSTANDARD;NETSTANDARD2_0</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
   <ItemGroup>
     <None Include="icon.png" Pack="true" PackagePath="\"/>


### PR DESCRIPTION
To fix:

```
    /opt/buildagent/work/22826069faf87cbf/src/TeamCitySharp/TeamCitySharp.csproj : warning NU1903: Package 'Newtonsoft.Json' 11.0.2 has a known high severity vulnerability, https://github.com/advisories/GHSA-5crp-9r3c-p9vr [/opt/buildagent/work/22826069faf87cbf/TeamCitySharp.sln]
```