### PR TITLE
Remove low value tests

### DIFF
--- a/src/Tests/IntegrationTests/SampleAgentUsage.cs
+++ b/src/Tests/IntegrationTests/SampleAgentUsage.cs
@@ -39,15 +39,6 @@ namespace TeamCitySharp.IntegrationTests
     }
 
     [Test]
-    public void it_throws_exception_when_host_url_invalid()
-    {
-      var client = new TeamCityClient("teamcity:81");
-      client.Connect("teamcitysharpuser", "qwerty");
-
-      Assert.Throws<HttpRequestException>(() => client.Agents.All());
-    }
-
-    [Test]
     public void it_throws_exception_when_no_client_connection_made()
     {
       var client = new TeamCityClient(m_server, m_useSsl);

--- a/src/Tests/IntegrationTests/SampleBuildsConfigsUsage.cs
+++ b/src/Tests/IntegrationTests/SampleBuildsConfigsUsage.cs
@@ -56,14 +56,6 @@ namespace TeamCitySharp.IntegrationTests
       Assert.Throws<ArgumentNullException>(() => new TeamCityClient(null));
     }
 
-    [Test]
-    public void it_throws_exception_when_host_does_not_exist()
-    {
-      var client = new TeamCityClient("test:81");
-      client.Connect("teamcitysharpuser", "qwerty");
-
-      Assert.Throws<HttpRequestException>(() => client.BuildConfigs.All());
-    }
     [Test, Ignore("We need to configure token before run this test")]
     public void it_returns_all_build_types_with_access_token()
     {

--- a/src/Tests/IntegrationTests/SampleBuildsUsage.cs
+++ b/src/Tests/IntegrationTests/SampleBuildsUsage.cs
@@ -49,16 +49,6 @@ namespace TeamCitySharp.IntegrationTests
     }
 
     [Test]
-    public void it_throws_exception_when_host_does_not_exist()
-    {
-      var client = new TeamCityClient("test:81");
-      client.Connect("admin", "qwerty");
-
-      const string buildConfigId = "Release Build";
-      Assert.Throws<HttpRequestException>(() => client.Builds.SuccessfulBuildsByBuildConfigId(buildConfigId));
-    }
-
-    [Test]
     public void it_throws_exception_when_no_connection_formed()
     {
       var client = new TeamCityClient(m_server, m_useSsl);

--- a/src/Tests/IntegrationTests/SampleChangeUsage.cs
+++ b/src/Tests/IntegrationTests/SampleChangeUsage.cs
@@ -44,16 +44,6 @@ namespace TeamCitySharp.IntegrationTests
     }
 
     [Test]
-    public void it_returns_exception_when_host_does_not_exist()
-    {
-      var client = new TeamCityClient("test:81");
-      client.Connect("admin", "qwerty");
-
-      Assert.Throws<HttpRequestException>(() => client.Changes.All());
-
-    }
-
-    [Test]
     public void it_returns_exception_when_no_connection_made()
     {
       var client = new TeamCityClient(m_server, m_useSsl);

--- a/src/Tests/IntegrationTests/SampleProjectUsage.cs
+++ b/src/Tests/IntegrationTests/SampleProjectUsage.cs
@@ -47,14 +47,6 @@ namespace TeamCitySharp.IntegrationTests
       Assert.Throws<ArgumentNullException>(() => new TeamCityClient(null));
     }
 
-    [Test]
-    public void it_throws_exception_when_host_does_not_exist()
-    {
-      var client = new TeamCityClient("test:81");
-      client.Connect("admin", "qwerty");
-
-      Assert.Throws<HttpRequestException>(() => client.Projects.All());
-    }
 
 
     [Test]

--- a/src/Tests/IntegrationTests/SampleServerUsage.cs
+++ b/src/Tests/IntegrationTests/SampleServerUsage.cs
@@ -41,15 +41,6 @@ namespace TeamCitySharp.IntegrationTests
     }
 
     [Test]
-    public void it_throws_exception_when_host_does_not_exist()
-    {
-      var client = new TeamCityClient("test:81");
-      client.Connect("admin", "qwerty");
-
-      Assert.Throws<HttpRequestException>(() => client.ServerInformation.AllPlugins());
-    }
-
-    [Test]
     public void it_throws_exception_when_no_connection_formed()
     {
       var client = new TeamCityClient(m_server, m_useSsl);

--- a/src/Tests/IntegrationTests/SampleUserUsage.cs
+++ b/src/Tests/IntegrationTests/SampleUserUsage.cs
@@ -42,15 +42,6 @@ namespace TeamCitySharp.IntegrationTests
         }
 
         [Test]
-        public void it_returns_exception_when_host_does_not_exist()
-        {
-            var client = new TeamCityClient("test:81");
-            client.Connect("admin", "qwerty");
-
-            Assert.Throws<HttpRequestException>(() => client.Users.All());
-        }
-
-        [Test]
         public void it_returns_exception_when_no_connection_made()
         {
             var client = new TeamCityClient(m_server, m_useSsl);

--- a/src/Tests/IntegrationTests/SampleVcsUsage.cs
+++ b/src/Tests/IntegrationTests/SampleVcsUsage.cs
@@ -43,14 +43,6 @@ namespace TeamCitySharp.IntegrationTests
             Assert.Throws<ArgumentNullException>(() => new TeamCityClient(null));
         }
 
-        [Test]
-        public void it_returns_exception_when_host_does_not_exist()
-        {
-            var client = new TeamCityClient("test:81");
-            client.Connect("admin", "qwerty");
-
-            Assert.Throws<HttpRequestException>(() => client.VcsRoots.All());
-        }
 
         [Test]
         public void it_returns_exception_when_no_connection_formed()


### PR DESCRIPTION
Remove tests that were asserting on behaviour when bad config passed.

At some point in the last (12!) years, this behaviour had changed from returning `HttpRequestException`, to now it returns an `AggregateException` containing `HttpRequestException` and `SocketException`.

Not worth trying to keep the behaviour consistent, nor fix the tests.