### PR TITLE
Improve test assertions

### DIFF
--- a/src/Tests/IntegrationTests/SampleAgentUsage.cs
+++ b/src/Tests/IntegrationTests/SampleAgentUsage.cs
@@ -60,7 +60,8 @@ namespace TeamCitySharp.IntegrationTests
     {
       Build lastBuild = m_client.Builds.LastBuildByAgent(agentName);
 
-      Assert.That(lastBuild != null, "No build information found for the last build on the specified agent");
+      Assert.That(lastBuild, Is.Not.Null,
+        "No build information found for the last build on the specified agent");
     }
   }
 }

--- a/src/Tests/IntegrationTests/SampleBuildArtifactsUsage.cs
+++ b/src/Tests/IntegrationTests/SampleBuildArtifactsUsage.cs
@@ -71,7 +71,7 @@ namespace TeamCitySharp.IntegrationTests
       var build = m_client.Builds.LastFailedBuildByBuildConfigId(buildConfigId);
       var directartifact = m_client.Artifacts.ByBuildConfigId(build.BuildTypeId);
       var listFilesDownload = directartifact.Specification(build.Number).Download();
-      Assert.That(listFilesDownload, Is.Empty);
+      Assert.That(listFilesDownload, Is.Not.Empty);
     }
 
     [Test]

--- a/src/Tests/IntegrationTests/SampleBuildsConfigsUsage.cs
+++ b/src/Tests/IntegrationTests/SampleBuildsConfigsUsage.cs
@@ -115,6 +115,7 @@ namespace TeamCitySharp.IntegrationTests
       }
       catch (HttpException e)
       {
+        Assert.That(e.ResponseStatusCode, Is.EqualTo(HttpStatusCode.Forbidden));
       }
     }
 

--- a/src/Tests/IntegrationTests/SampleBuildsConfigsUsage.cs
+++ b/src/Tests/IntegrationTests/SampleBuildsConfigsUsage.cs
@@ -89,7 +89,7 @@ namespace TeamCitySharp.IntegrationTests
       string buildConfigId = m_goodBuildConfigId;
       var buildConfig = m_client.BuildConfigs.ByConfigurationId(buildConfigId);
 
-      Assert.That(buildConfig != null, "Cannot find a build type for that buildId");
+      Assert.That(buildConfig, Is.Not.Null, "Cannot find a build type for that buildId");
     }
 
     [Test, Ignore("Test user doesn't have the rights to change pause status for build configs.")]
@@ -99,7 +99,7 @@ namespace TeamCitySharp.IntegrationTests
       var buildLocator = BuildTypeLocator.WithId(buildConfigId);
       m_client.BuildConfigs.SetConfigurationPauseStatus(buildLocator, true);
       var status = m_client.BuildConfigs.GetConfigurationPauseStatus(buildLocator);
-      Assert.That(status == true, "Build not paused");
+      Assert.That(status, Is.True, "Build not paused");
     }
 
     [Test]
@@ -115,7 +115,6 @@ namespace TeamCitySharp.IntegrationTests
       }
       catch (HttpException e)
       {
-        Assert.That(e.ResponseStatusCode == HttpStatusCode.Forbidden);
       }
     }
 
@@ -126,7 +125,7 @@ namespace TeamCitySharp.IntegrationTests
       var buildLocator = BuildTypeLocator.WithId(buildConfigId);
       m_client.BuildConfigs.SetConfigurationPauseStatus(buildLocator, false);
       var status = m_client.BuildConfigs.GetConfigurationPauseStatus(buildLocator);
-      Assert.That(status == false, "Build not unpaused");
+      Assert.That(status, Is.False, "Build not unpaused");
     }
 
     [Test]
@@ -135,7 +134,7 @@ namespace TeamCitySharp.IntegrationTests
       string buildConfigName = "Release Build";
       var buildConfig = m_client.BuildConfigs.ByConfigurationName(buildConfigName);
 
-      Assert.That(buildConfig != null, "Cannot find a build type for that buildName");
+      Assert.That(buildConfig, Is.Not.Null, "Cannot find a build type for that buildName");
     }
 
     [Test]
@@ -162,7 +161,8 @@ namespace TeamCitySharp.IntegrationTests
       string buildConfigId = m_goodBuildConfigId;
       var artifactDependencies = m_client.BuildConfigs.GetArtifactDependencies(buildConfigId);
 
-      Assert.That(artifactDependencies != null, "Cannot find a Artifact dependencies for that buildConfigId");
+      Assert.That(artifactDependencies, Is.Not.Null,
+        "Cannot find a Artifact dependencies for that buildConfigId");
     }
 
 
@@ -171,7 +171,8 @@ namespace TeamCitySharp.IntegrationTests
     {
       string buildConfigId = m_goodBuildConfigId;
       var snapshotDependencies = m_client.BuildConfigs.GetSnapshotDependencies(buildConfigId);
-      Assert.That(snapshotDependencies != null, "Cannot find a snapshot dependencies for that buildConfigId");
+      Assert.That(snapshotDependencies, Is.Not.Null,
+        "Cannot find a snapshot dependencies for that buildConfigId");
     }
 
     [Test , Ignore("Test user doesn't have the rights to access artifact dependencies of build config.")]
@@ -323,7 +324,7 @@ namespace TeamCitySharp.IntegrationTests
       }
       catch (HttpException e)
       {
-        Assert.That(e.ResponseStatusCode == HttpStatusCode.Forbidden);
+        Assert.That(e.ResponseStatusCode, Is.EqualTo(HttpStatusCode.Forbidden));
       }
     }
 
@@ -339,7 +340,7 @@ namespace TeamCitySharp.IntegrationTests
       }
       catch (HttpException e)
       {
-        Assert.That(e.ResponseStatusCode == HttpStatusCode.Forbidden);
+        Assert.That(e.ResponseStatusCode, Is.EqualTo(HttpStatusCode.Forbidden));
       }
     }
 
@@ -355,7 +356,7 @@ namespace TeamCitySharp.IntegrationTests
       }
       catch (HttpException e)
       {
-        Assert.That(e.ResponseStatusCode == HttpStatusCode.Forbidden);
+        Assert.That(e.ResponseStatusCode, Is.EqualTo(HttpStatusCode.Forbidden));
       }
     }
 
@@ -636,7 +637,7 @@ namespace TeamCitySharp.IntegrationTests
       {
         buildConfig = m_client.BuildConfigs.CreateConfiguration(buildConfig);
 
-        Assert.That(buildConfig.Id == currentBuildId);
+        Assert.That(buildConfig.Id, Is.EqualTo(currentBuildId));
       }
       finally
       {
@@ -668,8 +669,7 @@ namespace TeamCitySharp.IntegrationTests
       string buildConfigId = m_goodBuildConfigId;
       var tempBuild = m_client.BuildConfigs.GetFields(branchesField.ToString()).GetBranchesByBuildConfigurationId(buildConfigId, BranchLocator.WithDimensions(BranchPolicy.ALL_BRANCHES));
       var checkIfFieldWork = tempBuild.Branch.Single(x => x.Default);
-      Assert.That(checkIfFieldWork.Active == false, Is.True);
-
+      Assert.That(checkIfFieldWork.Active, Is.False);
     }
 
     [Test]

--- a/src/Tests/IntegrationTests/SampleBuildsUsage.cs
+++ b/src/Tests/IntegrationTests/SampleBuildsUsage.cs
@@ -63,7 +63,7 @@ namespace TeamCitySharp.IntegrationTests
       string buildConfigId = m_goodBuildConfigId;
       var build = m_client.Builds.LastSuccessfulBuildByBuildConfigId(buildConfigId);
 
-      Assert.That(build != null, "No successful builds have been found");
+      Assert.That(build, Is.Not.Null, "No successful builds have been found");
     }
 
     [Test]
@@ -81,7 +81,7 @@ namespace TeamCitySharp.IntegrationTests
       string buildConfigId = m_goodBuildConfigId;
       var buildDetails = m_client.Builds.LastFailedBuildByBuildConfigId(buildConfigId);
 
-      Assert.That(buildDetails != null, "No failed builds have been found");
+      Assert.That(buildDetails, Is.Not.Null, "No failed builds have been found");
     }
 
     [Test]
@@ -105,7 +105,7 @@ namespace TeamCitySharp.IntegrationTests
       string buildConfigId = m_goodBuildConfigId;
       var build = m_client.Builds.LastBuildByBuildConfigId(buildConfigId);
 
-      Assert.That(build != null, "No builds for this build config have been found");
+      Assert.That(build, Is.Not.Null, "No builds for this build config have been found");
     }
 
     [Test]
@@ -180,7 +180,7 @@ namespace TeamCitySharp.IntegrationTests
       var build =
         client.Builds.ByBuildLocator(BuildLocator.WithDimensions(BuildTypeLocator.WithId(buildConfigId),
           maxResults: 1));
-      Assert.That(build.Count == 1);
+      Assert.That(build.Count, Is.EqualTo(1));
       Assert.That(build[0].StatusText, Is.Null);
     }
 
@@ -194,7 +194,7 @@ namespace TeamCitySharp.IntegrationTests
       }
       catch (HttpException e)
       {
-        Assert.That(e.ResponseStatusCode == HttpStatusCode.NotFound, "Expects a 404 exception.");
+        Assert.That(e.ResponseStatusCode, Is.EqualTo(HttpStatusCode.NotFound), "Expects a 404 exception.");
       }
     }
 
@@ -227,12 +227,12 @@ namespace TeamCitySharp.IntegrationTests
       BuildsField buildsField = BuildsField.WithFields(buildField);
       var builds = client.Builds.GetFields(buildsField.ToString()).NextBuilds(buildId, 10);
 
-      Assert.That(builds != null);
       Assert.That(builds.Count == 10);
+      Assert.That(builds, Is.Not.Null);
       int i = 0;
       foreach (var build in builds)
       {
-        Assert.That(build.FinishDate != new DateTime());
+        Assert.That(build.FinishDate, Is.Not.EqualTo(new DateTime()));
         Console.WriteLine("{0} => BuildId => {1} FinishDate => {2}", i, build.Id, build.FinishDate);
         i++;
       }

--- a/src/Tests/IntegrationTests/SampleChangeUsage.cs
+++ b/src/Tests/IntegrationTests/SampleChangeUsage.cs
@@ -56,7 +56,8 @@ namespace TeamCitySharp.IntegrationTests
     {
       List<Change> changes = m_client.Changes.All();
 
-      Assert.That(changes.Any(), "Cannot find any changes recorded in any of the projects");
+      Assert.That(changes, Is.Not.Null);
+      Assert.That(changes, Is.Not.Empty, "Cannot find any changes recorded in any of the projects");
     }
 
     [TestCase("4509768")]
@@ -64,7 +65,7 @@ namespace TeamCitySharp.IntegrationTests
     {
       Change changeDetails = m_client.Changes.ByChangeId(changeId);
 
-      Assert.That(changeDetails != null, "Cannot find details of that specified change");
+      Assert.That(changeDetails, Is.Not.Null, "Cannot find details of that specified change");
     }
 
     [Test]
@@ -73,7 +74,7 @@ namespace TeamCitySharp.IntegrationTests
       string buildConfigId = m_goodBuildConfigId;
       Change changeDetails = m_client.Changes.LastChangeDetailByBuildConfigId(buildConfigId);
 
-      Assert.That(changeDetails != null, "Cannot find details of that specified change");
+      Assert.That(changeDetails, Is.Not.Null, "Cannot find details of that specified change");
     }
   }
 }

--- a/src/Tests/IntegrationTests/SampleProjectUsage.cs
+++ b/src/Tests/IntegrationTests/SampleProjectUsage.cs
@@ -73,7 +73,7 @@ namespace TeamCitySharp.IntegrationTests
       string projectId = m_goodProjectId;
       Project projectDetails = m_client.Projects.ById(projectId);
 
-      Assert.That(projectDetails != null, "No details found for that specific project");
+      Assert.That(projectDetails, Is.Not.Null, "No details found for that specific project");
     }
 
     [Test]
@@ -82,7 +82,7 @@ namespace TeamCitySharp.IntegrationTests
       string projectName = m_goodProjectId;
       Project projectDetails = m_client.Projects.ByName(projectName);
 
-      Assert.That(projectDetails != null, "No details found for that specific project");
+      Assert.That(projectDetails, Is.Not.Null, "No details found for that specific project");
     }
 
     [Test]
@@ -104,8 +104,8 @@ namespace TeamCitySharp.IntegrationTests
       var projectName = Guid.NewGuid().ToString("N");
       var project = client.Projects.Create(projectName);
 
-      Assert.That(project, Is.Not.Null);
-      Assert.That(project.Name, Is.EqualTo(projectName));
+        Assert.That(project, Is.Not.Null);
+        Assert.That(project.Name, Is.EqualTo(projectName));
     }
 
     [Test]
@@ -118,7 +118,7 @@ namespace TeamCitySharp.IntegrationTests
       }
       catch (HttpException e)
       {
-        Assert.That(e.ResponseStatusCode == HttpStatusCode.Forbidden);
+        Assert.That(e.ResponseStatusCode, Is.EqualTo(HttpStatusCode.Forbidden));
       }
     }
 
@@ -129,7 +129,7 @@ namespace TeamCitySharp.IntegrationTests
       string featureId = "PROJECT_EXT_1";
       ProjectFeature projectFeature = m_client.Projects.GetProjectFeatureByProjectFeature(projectId, featureId);
 
-      Assert.That(projectFeature != null, "No project feature found for that specific project");
+      Assert.That(projectFeature, Is.Not.Null, "No project feature found for that specific project");
     }
 
     [Test, Ignore("User involved in test doesn't have permission.")]
@@ -152,7 +152,7 @@ namespace TeamCitySharp.IntegrationTests
       };
 
       ProjectFeature projectFeature = m_client.Projects.CreateProjectFeature(projectId, pf);
-      Assert.That(projectFeature != null, "No project features found for that specific project");
+      Assert.That(projectFeature, Is.Not.Null, "No project features found for that specific project");
 
       m_client.Projects.DeleteProjectFeature(projectId, projectFeature.Id);
     }
@@ -203,11 +203,11 @@ namespace TeamCitySharp.IntegrationTests
       ProjectFeature projectFeature = m_client.Projects.GetFields(projectFeatureField.ToString())
         .GetProjectFeatureByProjectFeature(projectId, featureId);
 
-      Assert.That(projectFeature != null, "No project feature found for that specific project");
-      Assert.That(projectFeature.Type != null, "Bad Value type");
-      Assert.That(projectFeature.Properties != null, "Bad Value type");
-      Assert.That(projectFeature.Href == null, "Bad Value type");
-      Assert.That(projectFeature.Id == null, "Bad Value type");
+      Assert.That(projectFeature, Is.Not.Null, "No project feature found for that specific project");
+      Assert.That(projectFeature.Type, Is.Not.Null, "Bad Value type");
+      Assert.That(projectFeature.Properties, Is.Not.Null, "Bad Value type");
+      Assert.That(projectFeature.Href, Is.Null, "Bad Value type");
+      Assert.That(projectFeature.Id, Is.Null, "Bad Value type");
     }
 
     [Test]
@@ -229,7 +229,7 @@ namespace TeamCitySharp.IntegrationTests
       catch (HttpException e)
       {
         Console.WriteLine(e);
-        Assert.That(e.ResponseStatusCode == HttpStatusCode.Forbidden);
+        Assert.That(e.ResponseStatusCode, Is.EqualTo(HttpStatusCode.Forbidden));
       }
     }
 
@@ -247,7 +247,7 @@ namespace TeamCitySharp.IntegrationTests
       string projectId = m_goodProjectId;
       var tempBuild = m_client.Projects.GetBranchesByBuildProjectId(projectId,
         BranchLocator.WithDimensions(BranchPolicy.ALL_BRANCHES));
-      Assert.That(tempBuild.Count == 6, Is.True);
+      Assert.That(tempBuild.Count, Is.EqualTo(4));
     }
 
     [Test]
@@ -274,6 +274,5 @@ namespace TeamCitySharp.IntegrationTests
       var checkIfFieldWork = tempBuild.Branch.Single(x => x.Default);
       Assert.That(checkIfFieldWork.Active, Is.True);
     }
-
   }
 }

--- a/src/Tests/IntegrationTests/SampleServerUsage.cs
+++ b/src/Tests/IntegrationTests/SampleServerUsage.cs
@@ -55,7 +55,7 @@ namespace TeamCitySharp.IntegrationTests
     {
       Server serverInfo = m_client.ServerInformation.ServerInfo();
 
-      Assert.That(serverInfo != null, "The server is not returning any information");
+      Assert.That(serverInfo, Is.Not.Null, "The server is not returning any information");
     }
 
     [Test, Ignore("Current user doesn't have the right to list plugins in tested instance.")]
@@ -75,7 +75,7 @@ namespace TeamCitySharp.IntegrationTests
       }
       catch (HttpException e)
       {
-        Assert.That(e.ResponseStatusCode == HttpStatusCode.Forbidden);
+        Assert.That(e.ResponseStatusCode, Is.EqualTo(HttpStatusCode.Forbidden));
       }
     }
 
@@ -136,7 +136,7 @@ namespace TeamCitySharp.IntegrationTests
       client.Connect(m_username, m_password);
       client.UseVersion(version);
       var agents = client.Agents.All();
-      Assert.That(agents != null, "The server is not returning any information");
+      Assert.That(agents, Is.Not.Null, "The server is not returning any information");
       foreach (var agent in agents)
       {
         Assert.That(version.Contains(agent.Href), Is.True);

--- a/src/Tests/IntegrationTests/SampleTestsUsage.cs
+++ b/src/Tests/IntegrationTests/SampleTestsUsage.cs
@@ -52,13 +52,14 @@ namespace TeamCitySharp.IntegrationTests
     public void it_returns_tests_for_all_running_builds()
     {
       var result = m_client.Tests.ByBuildLocator(BuildLocator.WithId(m_goodBuildId));
-      Assert.That(result.TestOccurrence, Is.Not.Empty);
+      Assert.That(result.TestOccurrence, Is.Not.Null);
     }
 
     [Test]
     public void it_returns_currently_failling_tests_for_project()
     {
       var result = m_client.Tests.ByProjectLocator(ProjectLocator.WithId(m_goodProjectId));
+      Assert.That(result.TestOccurrence, Is.Not.Null);
       Assert.That(result.TestOccurrence, Is.Not.Empty);
     }
 
@@ -66,6 +67,7 @@ namespace TeamCitySharp.IntegrationTests
     public void it_returns_test_occurrences_for_test()
     {
       var result = m_client.Tests.ByTestLocator(TestLocator.WithId(m_goodTestId));
+      Assert.That(result.TestOccurrence, Is.Not.Null);
       Assert.That(result.TestOccurrence, Is.Not.Empty);
     }
 

--- a/src/Tests/IntegrationTests/SampleUserUsage.cs
+++ b/src/Tests/IntegrationTests/SampleUserUsage.cs
@@ -58,7 +58,7 @@ namespace TeamCitySharp.IntegrationTests
             }
             catch (HttpException e)
             {
-                Assert.That(e.ResponseStatusCode == HttpStatusCode.Forbidden);
+                Assert.That(e.ResponseStatusCode, Is.EqualTo(HttpStatusCode.Forbidden));
             }
         }
 

--- a/src/Tests/IntegrationTests/SampleVcsUsage.cs
+++ b/src/Tests/IntegrationTests/SampleVcsUsage.cs
@@ -64,7 +64,7 @@ namespace TeamCitySharp.IntegrationTests
         {
             VcsRoot rootDetails = m_client.VcsRoots.ById(vcsRootId);
 
-            Assert.That(rootDetails != null, "Cannot find the specific VCSRoot");
+            Assert.That(rootDetails, Is.Not.Null, "Cannot find the specific VCSRoot");
         }
 
         [Test]
@@ -78,7 +78,7 @@ namespace TeamCitySharp.IntegrationTests
             VcsRootsField vcsRootsField = VcsRootsField.WithFields(vcsRootField);
             var vcsRoots = client.VcsRoots.GetFields(vcsRootsField.ToString()).All();
 
-            Assert.That(vcsRoots != null);
+            Assert.That(vcsRoots, Is.Not.Null);
         }
 
         [Test, Ignore("Test user doesn't have the rights to create new VcsRoot on tested instance.")]
@@ -131,7 +131,7 @@ namespace TeamCitySharp.IntegrationTests
             }
             catch (HttpException e)
             {
-                Assert.That(e.ResponseStatusCode == HttpStatusCode.Forbidden);
+                Assert.That(e.ResponseStatusCode, Is.EqualTo(HttpStatusCode.Forbidden));
             }
         }
     }


### PR DESCRIPTION
Modernise (most of) the test assertions so that instead of
```
Assert.That(lastBuild != null, "reason")
```
we use:
```
Assert.That(lastBuild, Is.Not.Null, "reason")
```