### PR TITLE
Read magic values from config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -328,3 +328,4 @@ ASALocalRun/
 
 # MFractors (Xamarin productivity tool) working folder 
 .mfractor/
+**/appsettings.development.json

--- a/src/Tests/IntegrationTests/SampleBuildArtifactsUsage.cs
+++ b/src/Tests/IntegrationTests/SampleBuildArtifactsUsage.cs
@@ -78,9 +78,9 @@ namespace TeamCitySharp.IntegrationTests
     [Test]
     public async Task it_download_artifact()
     {
-      var buildConfigId = m_goodBuildConfigId;
+      var buildConfigId = Configuration.GetAppSetting("IdOfBuildConfigWithArtifact");
 
-      const string filename = "Outputs.zip";
+      var filename = Configuration.GetAppSetting("ArtifactNameForBuildConfigWithArtifact");
       var expectedFile = Path.Combine(Path.GetTempPath(), "expectedFile.zip");
       var expectedUrl = $"http://{m_server}/repository/download/{buildConfigId}/.lastSuccessful/{filename}";
       var artifact = m_client.Artifacts.ByBuildConfigId(buildConfigId);
@@ -120,9 +120,9 @@ namespace TeamCitySharp.IntegrationTests
     [Test]
     public async Task it_download_artifact_from_a_git_branch()
     {
-      var buildConfigId = m_goodBuildConfigId;
-      const string filename = "Outputs.zip";
-      const string param = "branch=dev-2001";
+      var buildConfigId = Configuration.GetAppSetting("IdOfBuildConfigWithArtifactAndVcsRoot");
+      var filename = Configuration.GetAppSetting("ArtifactNameForBuildConfigWithArtifactAndVcsRoot");
+      var param = $"branch={Configuration.GetAppSetting("BranchNameForBuildConfigWithArtifactAndVcsRoot")}";
       var expectedFile = Path.Combine(Path.GetTempPath(), "expectedFile.zip");
       var expectedUrl = $"http://{m_server}/repository/download/{buildConfigId}/.lastSuccessful/{filename}?{HttpUtility.UrlDecode(param)}";
       var artifact = m_client.Artifacts.ByBuildConfigId(buildConfigId, param);

--- a/src/Tests/IntegrationTests/SampleBuildQueueUsage.cs
+++ b/src/Tests/IntegrationTests/SampleBuildQueueUsage.cs
@@ -23,8 +23,6 @@ namespace TeamCitySharp.IntegrationTests
     private readonly string m_username;
     private readonly string m_password;
     private readonly string m_queuedBuildConfigId;
-    private readonly string m_queuedProjectId;
-
 
     public when_interacting_to_get_build_queue_info()
     {
@@ -33,7 +31,6 @@ namespace TeamCitySharp.IntegrationTests
       m_username = Configuration.GetAppSetting("Username");
       m_password = Configuration.GetAppSetting("Password");
       m_queuedBuildConfigId = Configuration.GetAppSetting("QueuedBuildConfigId");
-      m_queuedProjectId = Configuration.GetAppSetting("QueuedProjectId");
     }
 
     [SetUp]
@@ -54,7 +51,8 @@ namespace TeamCitySharp.IntegrationTests
     [Test]
     public void it_returns_the_builds_queued_by_project_id()
     {
-      var result = m_client.BuildQueue.ByProjectLocater(ProjectLocator.WithId(m_queuedProjectId));
+      var projectId = Configuration.GetAppSetting("IdOfProjectWithQueuedBuilds");
+      var result = m_client.BuildQueue.ByProjectLocater(ProjectLocator.WithId(projectId));
 
       Assert.That(result, Is.Not.Empty);
     }

--- a/src/Tests/IntegrationTests/SampleBuildsConfigsUsage.cs
+++ b/src/Tests/IntegrationTests/SampleBuildsConfigsUsage.cs
@@ -111,7 +111,7 @@ namespace TeamCitySharp.IntegrationTests
       try
       {
         var client = new TeamCityClient(m_server, m_useSsl);
-        client.ConnectAsGuest();
+        client.Connect(Configuration.GetAppSetting("NonAdminUser"), m_password);
         client.BuildConfigs.SetConfigurationPauseStatus(buildLocator, true);
       }
       catch (HttpException e)
@@ -133,7 +133,7 @@ namespace TeamCitySharp.IntegrationTests
     [Test]
     public void it_returns_build_config_details_by_configuration_name()
     {
-      string buildConfigName = "Release Build";
+      string buildConfigName = Configuration.GetAppSetting("NameOfBuildConfigWithTests");
       var buildConfig = m_client.BuildConfigs.ByConfigurationName(buildConfigName);
 
       Assert.That(buildConfig, Is.Not.Null, "Cannot find a build type for that buildName");
@@ -151,7 +151,7 @@ namespace TeamCitySharp.IntegrationTests
     [Test]
     public void it_returns_build_configs_by_project_name()
     {
-      string projectName = m_goodProjectId;
+      var projectName = Configuration.GetAppSetting("NameOfProjectWithBuildConfigs");
       var buildConfigs = m_client.BuildConfigs.ByProjectName(projectName);
 
       Assert.That(buildConfigs.Any(), "Cannot find a build type for that projectName");
@@ -317,11 +317,10 @@ namespace TeamCitySharp.IntegrationTests
     [Test]
     public void it_throws_exception_artifact_dependencies_by_build_config_id_forbidden()
     {
-
       try
       {
         var client = new TeamCityClient(m_server, m_useSsl);
-        client.ConnectAsGuest();
+        client.Connect(Configuration.GetAppSetting("NonAdminUser"), m_password);
         client.BuildConfigs.GetArtifactDependencies(m_goodBuildConfigId);
       }
       catch (HttpException e)
@@ -337,7 +336,7 @@ namespace TeamCitySharp.IntegrationTests
       try
       {
         var client = new TeamCityClient(m_server, m_useSsl);
-        client.ConnectAsGuest();
+        client.Connect(Configuration.GetAppSetting("NonAdminUser"), m_password);
         client.BuildConfigs.GetSnapshotDependencies(m_goodBuildConfigId);
       }
       catch (HttpException e)
@@ -352,7 +351,7 @@ namespace TeamCitySharp.IntegrationTests
       try
       {
         var client = new TeamCityClient(m_server, m_useSsl);
-        client.ConnectAsGuest();
+        client.Connect(Configuration.GetAppSetting("NonAdminUser"), m_password);
         client.BuildConfigs.CreateConfigurationByProjectId(m_goodProjectId, "testNewConfig");
       }
       catch (HttpException e)
@@ -521,10 +520,10 @@ namespace TeamCitySharp.IntegrationTests
     public void it_returns_first_build_types_builds_investigations_compatible_agents_field_null()
 
     {
-      var tempBuildConfig = m_client.BuildConfigs.All().First();
+      var tempBuildConfigId =Configuration.GetAppSetting("IdOfBuildConfigWithTests");
       // Section 1
       var buildTypeField = BuildTypeField.WithFields(id:true);
-      var buildConfig = m_client.BuildConfigs.GetFields(buildTypeField.ToString()).ByConfigurationId(tempBuildConfig.Id);
+      var buildConfig = m_client.BuildConfigs.GetFields(buildTypeField.ToString()).ByConfigurationId(tempBuildConfigId);
       Assert.That(buildConfig.Builds, Is.Null, "No builds 1");
       Assert.That(buildConfig.Investigations, Is.Null, "No Investigations 1");
       Assert.That(buildConfig.CompatibleAgents, Is.Null, "No CompatibleAgents 1");
@@ -534,11 +533,11 @@ namespace TeamCitySharp.IntegrationTests
       var investigationsField = InvestigationsField.WithFields();
       var compatibleAgentsField = CompatibleAgentsField.WithFields();
       buildTypeField = BuildTypeField.WithFields(id: true, builds: buildsField,investigations: investigationsField, compatibleAgents:compatibleAgentsField);
-      buildConfig = m_client.BuildConfigs.GetFields(buildTypeField.ToString()).ByConfigurationId(tempBuildConfig.Id);
+      buildConfig = m_client.BuildConfigs.GetFields(buildTypeField.ToString()).ByConfigurationId(tempBuildConfigId);
       Assert.That(buildConfig.Builds, Is.Not.Null, "No builds 2");
       Assert.That(buildConfig.Builds.Href, Is.Null, "No builds href 2");
       Assert.That(buildConfig.Investigations, Is.Not.Null, "No Investigations 2");
-      Assert.That(buildConfig.Investigations.Href, Is.Not.Null, "No Investigations href 2");
+      Assert.That(buildConfig.Investigations.Href, Is.Null, "No Investigations href 2");
       Assert.That(buildConfig.CompatibleAgents, Is.Not.Null, "No CompatibleAgents 2");
       Assert.That(buildConfig.CompatibleAgents.Href, Is.Not.Null, "No CompatibleAgents href 2");
 
@@ -547,7 +546,7 @@ namespace TeamCitySharp.IntegrationTests
       investigationsField = InvestigationsField.WithFields(href:true);
       compatibleAgentsField = CompatibleAgentsField.WithFields(href:true);
       buildTypeField = BuildTypeField.WithFields(id: true, builds: buildsField, investigations: investigationsField, compatibleAgents: compatibleAgentsField);
-      buildConfig = m_client.BuildConfigs.GetFields(buildTypeField.ToString()).ByConfigurationId(tempBuildConfig.Id);
+      buildConfig = m_client.BuildConfigs.GetFields(buildTypeField.ToString()).ByConfigurationId(tempBuildConfigId);
       Assert.That(buildConfig.Builds, Is.Not.Null, "No builds 3");
       Assert.That(buildConfig.Builds.Href, Is.Not.Null, "No builds href 3");
       Assert.That(buildConfig.Investigations, Is.Not.Null, "No Investigations 3");
@@ -652,17 +651,17 @@ namespace TeamCitySharp.IntegrationTests
     [Test]
     public void it_returns_branches()
     {
-      string buildConfigId = m_goodBuildConfigId;
+      string buildConfigId = Configuration.GetAppSetting("IdOfBuildConfigWithArtifactAndVcsRoot");
       var tempBuild = m_client.BuildConfigs.GetBranchesByBuildConfigurationId(buildConfigId);
-      Assert.That(tempBuild.Count == 2, Is.True);
+      Assert.That(tempBuild.Count, Is.EqualTo(int.Parse(Configuration.GetAppSetting("NumberOfBranchesForBuildConfigWithArtifactAndVcsRoot"))));
     }
 
     [Test]
     public void it_returns_branches_history()
     {
-      string buildConfigId = m_goodBuildConfigId;
+      string buildConfigId = Configuration.GetAppSetting("IdOfBuildConfigWithArtifactAndVcsRoot");
       var tempBuild = m_client.BuildConfigs.GetBranchesByBuildConfigurationId(buildConfigId,BranchLocator.WithDimensions(BranchPolicy.ALL_BRANCHES));
-      Assert.That(tempBuild.Count == 6, Is.True);
+      Assert.That(tempBuild.Count, Is.EqualTo(int.Parse(Configuration.GetAppSetting("NumberOfBranchesForBuildConfigWithArtifactAndVcsRoot"))));
     }
 
     [Test]

--- a/src/Tests/IntegrationTests/SampleBuildsConfigsUsage.cs
+++ b/src/Tests/IntegrationTests/SampleBuildsConfigsUsage.cs
@@ -537,7 +537,7 @@ namespace TeamCitySharp.IntegrationTests
       Assert.That(buildConfig.Builds, Is.Not.Null, "No builds 2");
       Assert.That(buildConfig.Builds.Href, Is.Null, "No builds href 2");
       Assert.That(buildConfig.Investigations, Is.Not.Null, "No Investigations 2");
-      Assert.That(buildConfig.Investigations.Href, Is.Null, "No Investigations href 2");
+      Assert.That(buildConfig.Investigations.Href, Is.Not.Null, "No Investigations href 2");
       Assert.That(buildConfig.CompatibleAgents, Is.Not.Null, "No CompatibleAgents 2");
       Assert.That(buildConfig.CompatibleAgents.Href, Is.Not.Null, "No CompatibleAgents href 2");
 

--- a/src/Tests/IntegrationTests/SampleBuildsUsage.cs
+++ b/src/Tests/IntegrationTests/SampleBuildsUsage.cs
@@ -20,8 +20,6 @@ namespace TeamCitySharp.IntegrationTests
     private readonly string m_username;
     private readonly string m_password;
     private readonly string m_goodBuildConfigId;
-    private readonly string m_goodNumber;
-
 
     public when_interacting_to_get_build_status_info()
     {

--- a/src/Tests/IntegrationTests/SampleBuildsUsage.cs
+++ b/src/Tests/IntegrationTests/SampleBuildsUsage.cs
@@ -20,7 +20,6 @@ namespace TeamCitySharp.IntegrationTests
     private readonly string m_username;
     private readonly string m_password;
     private readonly string m_goodBuildConfigId;
-    private readonly string m_goodProjectId;
     private readonly string m_goodNumber;
 
 
@@ -31,8 +30,6 @@ namespace TeamCitySharp.IntegrationTests
       m_username = Configuration.GetAppSetting("Username");
       m_password = Configuration.GetAppSetting("Password");
       m_goodBuildConfigId = Configuration.GetAppSetting("GoodBuildConfigId");
-      m_goodProjectId = Configuration.GetAppSetting("GoodProjectId");
-      m_goodNumber = Configuration.GetAppSetting("GoodNumber");
     }
 
     [SetUp]
@@ -201,8 +198,8 @@ namespace TeamCitySharp.IntegrationTests
     [Test]
     public void it_returns_correct_next_builds()
     {
-      const string buildId = "5726";
       var client = new TeamCityClient(m_server, m_useSsl);
+      var buildId = Configuration.GetAppSetting("IdOfBuildWithSubsequentBuilds");
       client.Connect(m_username, m_password);
 
       var builds = client.Builds.NextBuilds(buildId, 10);
@@ -213,14 +210,14 @@ namespace TeamCitySharp.IntegrationTests
       }
 
       Assert.That(builds, Is.Not.Null);
-      Assert.That(builds.Count == 10);
+      Assert.That(builds.Count, Is.EqualTo(int.Parse(Configuration.GetAppSetting("NumberOfSubsequentBuilds"))));
     }
 
     [Test]
     public void it_returns_correct_next_builds_with_filter()
     {
-      const string buildId = "5726";
       var client = new TeamCityClient(m_server, m_useSsl);
+      var buildId = Configuration.GetAppSetting("IdOfBuildWithSubsequentBuilds");
       client.Connect(m_username, m_password);
 
       BuildField buildField = BuildField.WithFields(id: true, number: true, finishDate: true);
@@ -238,16 +235,16 @@ namespace TeamCitySharp.IntegrationTests
       }
     }
 
-    [Test, Ignore("m_goodNumber is not pointing to a valid number anymore.")]
+    [Test]
     public void it_pin_by_config()
     {
-      m_client.Builds.PinBuildByBuildNumber(m_goodBuildConfigId, m_goodNumber, "Automated Comment");
+      m_client.Builds.PinBuildByBuildNumber(Configuration.GetAppSetting("IdOfBuildConfigWithTests"), Configuration.GetAppSetting("BuildNumberOfBuildToPin"), "Automated Comment");
     }
 
-    [Test, Ignore("m_goodNumber is not pointing to a valid number anymore.")]
+    [Test]
     public void it_unpin_by_config()
     {
-      m_client.Builds.UnPinBuildByBuildNumber(m_goodBuildConfigId, m_goodNumber);
+      m_client.Builds.UnPinBuildByBuildNumber(Configuration.GetAppSetting("IdOfBuildConfigWithTests"), Configuration.GetAppSetting("BuildNumberOfBuildToPin"));
     }
 
 
@@ -255,8 +252,7 @@ namespace TeamCitySharp.IntegrationTests
     public void it_returns_first_build_artifacts_relatedIssues_Statistics_no_field()
 
     {
-      var tempBuildConfig = m_client.BuildConfigs.All().First();
-      var tempBuild = m_client.Builds.LastBuildByBuildConfigId(tempBuildConfig.Id);
+      var tempBuild = m_client.Builds.LastBuildByBuildConfigId(Configuration.GetAppSetting("IdOfBuildConfigWithTests"));
       var build = m_client.Builds.ById(tempBuild.Id);
 
       Assert.That(build.Artifacts, Is.Not.Null, "No Artifacts ");
@@ -269,13 +265,10 @@ namespace TeamCitySharp.IntegrationTests
 
     [Test]
     public void it_returns_first_build_types_builds_investigations_compatible_agents_field_null()
-
     {
-      var tempBuildConfig = m_client.BuildConfigs.All().First();
-
       // Section 1
       var buildField = BuildField.WithFields(number: true, id: true);
-      var tempBuild = m_client.Builds.LastBuildByBuildConfigId(tempBuildConfig.Id);
+      var tempBuild = m_client.Builds.LastBuildByBuildConfigId(Configuration.GetAppSetting("IdOfBuildConfigWithTests"));
       var build = m_client.Builds.GetFields(buildField.ToString()).ById(tempBuild.Id);
       Assert.That(build.Artifacts, Is.Null, "No Artifacts 1");
       Assert.That(build.RelatedIssues, Is.Null, "No RelatedIssues 1");
@@ -287,7 +280,7 @@ namespace TeamCitySharp.IntegrationTests
       var statisticsField = StatisticsField.WithFields();
       buildField = BuildField.WithFields(id: true, artifacts: artifactsField, relatedIssues: relatedIssuesField,
         statistics: statisticsField);
-      tempBuild = m_client.Builds.LastBuildByBuildConfigId(tempBuildConfig.Id);
+      tempBuild = m_client.Builds.LastBuildByBuildConfigId(Configuration.GetAppSetting("IdOfBuildConfigWithTests"));
       build = m_client.Builds.GetFields(buildField.ToString()).ById(tempBuild.Id);
       Assert.That(build.Artifacts, Is.Not.Null, "No Artifacts 2");
       Assert.That(build.Artifacts.Href, Is.Not.Null, "No Artifacts href 2");
@@ -302,7 +295,7 @@ namespace TeamCitySharp.IntegrationTests
       relatedIssuesField = RelatedIssuesField.WithFields(href: true);
       buildField = BuildField.WithFields(id: true, artifacts: artifactsField, relatedIssues: relatedIssuesField,
         statistics: statisticsField);
-      tempBuild = m_client.Builds.LastBuildByBuildConfigId(tempBuildConfig.Id);
+      tempBuild = m_client.Builds.LastBuildByBuildConfigId(Configuration.GetAppSetting("IdOfBuildConfigWithTests"));
       build = m_client.Builds.GetFields(buildField.ToString()).ById(tempBuild.Id);
       Assert.That(build.Artifacts, Is.Not.Null, "No Artifacts 3");
       Assert.That(build.Artifacts.Href, Is.Not.Null, "No Artifacts href 3");
@@ -315,9 +308,6 @@ namespace TeamCitySharp.IntegrationTests
     [Test]
     public void it_returns_full_build_field_1()
     {
-      var tempBuildConfig = m_client.BuildConfigs.All().First();
-
-
       var buildField = BuildField.WithFields(id: true, taskId: true, buildTypeId: true, buildTypeInternalId: true,
         number: true, status: true, state: true, running: true, composite: true, failedToStart: true, personal: true,
         percentageComplete: true,
@@ -326,7 +316,7 @@ namespace TeamCitySharp.IntegrationTests
         startEstimate: true, waitReason: true,
         startDate: true, finishDate: true, queuedDate: true, settingsHash: true, currentSettingsHash: true,
         modificationId: true, chainModificationId: true, usedByOtherBuilds: true);
-      var tempBuild = m_client.Builds.LastBuildByBuildConfigId(tempBuildConfig.Id);
+      var tempBuild = m_client.Builds.LastBuildByBuildConfigId(Configuration.GetAppSetting("IdOfBuildConfigWithTests"));
       var build = m_client.Builds.GetFields(buildField.ToString()).ById(tempBuild.Id);
       Assert.That(build.Id, Is.Not.Null);
     }
@@ -334,7 +324,6 @@ namespace TeamCitySharp.IntegrationTests
     [Test]
     public void it_returns_full_build_field_2()
     {
-      var tempBuildConfig = m_client.BuildConfigs.All().First();
       ItemsField itemsField = ItemsField.WithFields(item: true);
       BuildsField buildsField = BuildsField.WithFields();
       RelatedField relatedField = RelatedField.WithFields(builds: buildsField);
@@ -379,7 +368,7 @@ namespace TeamCitySharp.IntegrationTests
         statusChangeComment: commentField, relatedIssues: relatedIssuesField, replacementIds: itemsField,
         related: relatedField);
 
-      var tempBuild = m_client.Builds.LastBuildByBuildConfigId(tempBuildConfig.Id);
+      var tempBuild = m_client.Builds.LastBuildByBuildConfigId(Configuration.GetAppSetting("IdOfBuildConfigWithTests"));
       var build = m_client.Builds.GetFields(buildField.ToString()).ById(tempBuild.Id);
       Assert.That(build, Is.Not.Null);
     }
@@ -392,7 +381,7 @@ namespace TeamCitySharp.IntegrationTests
       PropertyField propertyField = PropertyField.WithFields(name:true,value:true);
       PropertiesField propertiesField = PropertiesField.WithFields(propertyField: propertyField);
       var buildField = BuildField.WithFields(resultingProperties:propertiesField);
-      var tempBuild = m_client.Builds.LastBuildByBuildConfigId(tempBuildConfig.Id);
+      var tempBuild = m_client.Builds.LastBuildByBuildConfigId(Configuration.GetAppSetting("IdOfBuildConfigWithTests"));
       var build = m_client.Builds.GetFields(buildField.ToString()).ById(tempBuild.Id);
       Assert.That(build, Is.Not.Null);
     }
@@ -405,7 +394,7 @@ namespace TeamCitySharp.IntegrationTests
       EntryField entryField = EntryField.WithFields(name:true,value:true);
       EntriesField entriesField = EntriesField.WithFields(entry: entryField);
       var buildField = BuildField.WithFields( attributes: entriesField);
-      var tempBuild = m_client.Builds.LastBuildByBuildConfigId(tempBuildConfig.Id);
+      var tempBuild = m_client.Builds.LastBuildByBuildConfigId(Configuration.GetAppSetting("IdOfBuildConfigWithTests"));
       var build = m_client.Builds.GetFields(buildField.ToString()).ById(tempBuild.Id);
       Assert.That(build, Is.Not.Null);
     }
@@ -420,7 +409,7 @@ namespace TeamCitySharp.IntegrationTests
       BuildTypeField buildTypeField = BuildTypeField.WithFields(id: true);
       TriggeredField triggeredField = TriggeredField.WithFields(buildType: buildTypeField,type:true,date:true,details:true,user:userField,displayText:true,rawValue:true, build:buildField1);
       var buildField = BuildField.WithFields(triggered: triggeredField);
-      var tempBuild = m_client.Builds.LastBuildByBuildConfigId(tempBuildConfig.Id);
+      var tempBuild = m_client.Builds.LastBuildByBuildConfigId(Configuration.GetAppSetting("IdOfBuildConfigWithTests"));
       var build = m_client.Builds.GetFields(buildField.ToString()).ById(tempBuild.Id);
       Assert.That(build, Is.Not.Null);
     }
@@ -434,7 +423,7 @@ namespace TeamCitySharp.IntegrationTests
       BuildChangeField buildChangeField = BuildChangeField.WithFields(nextBuild: buildField1, prevBuild: buildField1);
       BuildChangesField buildChangesField = BuildChangesField.WithFields(buildChange: buildChangeField);
       var buildField = BuildField.WithFields(artifactDependencyChanges: buildChangesField);
-      var tempBuild = m_client.Builds.LastBuildByBuildConfigId(tempBuildConfig.Id);
+      var tempBuild = m_client.Builds.LastBuildByBuildConfigId(Configuration.GetAppSetting("IdOfBuildConfigWithTests"));
       var build = m_client.Builds.GetFields(buildField.ToString()).ById(tempBuild.Id);
       Assert.That(build, Is.Not.Null);
     }
@@ -446,7 +435,7 @@ namespace TeamCitySharp.IntegrationTests
       LinkField linkField = LinkField.WithFields(type:true,url:true, relativeUrl: true);
       LinksField linksField = LinksField.WithFields(link:linkField);
       var buildField = BuildField.WithFields(links:linksField);
-      var tempBuild = m_client.Builds.LastBuildByBuildConfigId(tempBuildConfig.Id);
+      var tempBuild = m_client.Builds.LastBuildByBuildConfigId(Configuration.GetAppSetting("IdOfBuildConfigWithTests"));
       var build = m_client.Builds.GetFields(buildField.ToString()).ById(tempBuild.Id);
       Assert.That(build, Is.Not.Null);
     }
@@ -454,10 +443,9 @@ namespace TeamCitySharp.IntegrationTests
     [Test]
     public void it_returns_full_build_field_versionedSettingsRevision()
     {
-      var tempBuildConfig = m_client.BuildConfigs.All().First();
       RevisionField revisionField = RevisionField.WithFields(version: true);
       var buildField = BuildField.WithFields(versionedSettingsRevision: revisionField);
-      var tempBuild = m_client.Builds.LastBuildByBuildConfigId(tempBuildConfig.Id);
+      var tempBuild = m_client.Builds.LastBuildByBuildConfigId(Configuration.GetAppSetting("IdOfBuildConfigWithTests"));
       var build = m_client.Builds.GetFields(buildField.ToString()).ById(tempBuild.Id);
       Assert.That(build, Is.Not.Null);
     }
@@ -469,7 +457,7 @@ namespace TeamCitySharp.IntegrationTests
       PropertyField propertyField = PropertyField.WithFields(name: true, value: true);
       StatisticsField statisticsField = StatisticsField.WithFields(propertyField: propertyField,href:true, count:true);
       BuildField buildField = BuildField.WithFields(statistics: statisticsField);
-      var tempBuild = m_client.Builds.LastBuildByBuildConfigId(tempBuildConfig.Id);
+      var tempBuild = m_client.Builds.LastBuildByBuildConfigId(Configuration.GetAppSetting("IdOfBuildConfigWithTests"));
       var build = m_client.Builds.GetFields(buildField.ToString()).ById(tempBuild.Id);
       Assert.That(build.Statistics.Href, Is.Not.Null);
       Assert.That(build.Statistics.Count, Is.Not.Null);
@@ -479,8 +467,7 @@ namespace TeamCitySharp.IntegrationTests
     [Test]
     public void it_returns_full_build_field_statistics_without_build ()
     {
-      var tempBuildConfig = m_client.BuildConfigs.All().First();
-      var tempBuild = m_client.Builds.LastBuildByBuildConfigId(tempBuildConfig.Id);
+      var tempBuild = m_client.Builds.LastBuildByBuildConfigId(Configuration.GetAppSetting("IdOfBuildConfigWithTests"));
       PropertyField propertyField = PropertyField.WithFields(name: true, value: true);
       StatisticsField statisticsField = StatisticsField.WithFields(propertyField: propertyField, href: true, count: true);
       var stats = m_client.Statistics.GetFields(statisticsField.ToString()).GetByBuildId(tempBuild.Id);

--- a/src/Tests/IntegrationTests/SampleChangeUsage.cs
+++ b/src/Tests/IntegrationTests/SampleChangeUsage.cs
@@ -76,7 +76,7 @@ namespace TeamCitySharp.IntegrationTests
     [Test]
     public void it_returns_change_details_for_build_config()
     {
-      string buildConfigId = m_goodBuildConfigId;
+      string buildConfigId = Configuration.GetAppSetting("IdOfBuildConfigWithArtifactAndVcsRoot");
       Change changeDetails = m_client.Changes.LastChangeDetailByBuildConfigId(buildConfigId);
 
       Assert.That(changeDetails, Is.Not.Null, "Cannot find details of that specified change");

--- a/src/Tests/IntegrationTests/SampleProjectUsage.cs
+++ b/src/Tests/IntegrationTests/SampleProjectUsage.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Configuration;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
@@ -79,7 +78,7 @@ namespace TeamCitySharp.IntegrationTests
     [Test]
     public void it_returns_project_details_when_passing_a_project_name()
     {
-      string projectName = m_goodProjectId;
+      string projectName = Configuration.GetAppSetting("NameOfProjectWithBuildConfigs");
       Project projectDetails = m_client.Projects.ByName(projectName);
 
       Assert.That(projectDetails, Is.Not.Null, "No details found for that specific project");
@@ -243,7 +242,7 @@ namespace TeamCitySharp.IntegrationTests
     [Test]
     public void it_returns_branches_history()
     {
-      string projectId = m_goodProjectId;
+      string projectId = Configuration.GetAppSetting("IdOfProjectWithQueuedBuilds");
       var tempBuild = m_client.Projects.GetBranchesByBuildProjectId(projectId,
         BranchLocator.WithDimensions(BranchPolicy.ALL_BRANCHES));
       Assert.That(tempBuild.Count, Is.EqualTo(4));

--- a/src/Tests/IntegrationTests/SampleStatisticsUsage.cs
+++ b/src/Tests/IntegrationTests/SampleStatisticsUsage.cs
@@ -33,8 +33,7 @@ namespace TeamCitySharp.IntegrationTests
     [Test]
     public void it_returns_no_of_tests_from_last_successful_build()
     {
-      var proj = m_client.Projects.ById(m_goodProjectId);
-      var build = m_client.Builds.LastSuccessfulBuildByBuildConfigId(proj.BuildTypes.BuildType[0].Id);
+      var build = m_client.Builds.LastSuccessfulBuildByBuildConfigId(Configuration.GetAppSetting("IdOfBuildConfigWithTests"));
       var stats = m_client.Statistics.GetByBuildId(build.Id);
 
       Assert.That(stats.Property.Any(property => property.Name.Equals("PassedTestCount")));

--- a/src/Tests/IntegrationTests/SampleTestsUsage.cs
+++ b/src/Tests/IntegrationTests/SampleTestsUsage.cs
@@ -19,7 +19,6 @@ namespace TeamCitySharp.IntegrationTests
     private readonly bool m_useSsl;
     private readonly string m_username;
     private readonly string m_password;
-    private readonly int m_goodBuildId;
     private readonly string m_goodProjectId;
     private readonly string m_goodTestId;
 
@@ -30,7 +29,6 @@ namespace TeamCitySharp.IntegrationTests
       bool.TryParse(Configuration.GetAppSetting("UseSsl"), out m_useSsl);
       m_username = Configuration.GetAppSetting("Username");
       m_password = Configuration.GetAppSetting("Password");
-      int.TryParse(Configuration.GetAppSetting("GoodBuildId"), out m_goodBuildId);
       m_goodProjectId = Configuration.GetAppSetting("GoodProjectId");
       m_goodTestId = Configuration.GetAppSetting("GoodTestId");
     }
@@ -51,7 +49,7 @@ namespace TeamCitySharp.IntegrationTests
     [Test]
     public void it_returns_tests_for_all_running_builds()
     {
-      var result = m_client.Tests.ByBuildLocator(BuildLocator.WithId(m_goodBuildId));
+      var result = m_client.Tests.ByBuildLocator(BuildLocator.WithId(int.Parse(Configuration.GetAppSetting("BuildWithTestsId"))));
       Assert.That(result.TestOccurrence, Is.Not.Null);
     }
 
@@ -74,7 +72,7 @@ namespace TeamCitySharp.IntegrationTests
     [Test]
     public void it_returns_all_tests_for_all_running_builds()
     {
-      var result = m_client.Tests.All(BuildLocator.WithId(m_goodBuildId));
+      var result = m_client.Tests.All(BuildLocator.WithId(int.Parse(Configuration.GetAppSetting("BuildWithTestsId"))));
       Assert.That(result, Is.Not.Empty);
     }
 

--- a/src/Tests/IntegrationTests/SampleUserUsage.cs
+++ b/src/Tests/IntegrationTests/SampleUserUsage.cs
@@ -128,7 +128,7 @@ namespace TeamCitySharp.IntegrationTests
         [Test]
         public void it_should_throw_exception_when_forbidden_status_code_returned()
         {
-            var client = new TeamCityClient(m_server, m_useSsl, Configuration.GetWireMockClient);
+            var client = new TeamCityClient(m_server, m_useSsl);
             client.ConnectAsGuest();
 
             Assert.Throws<HttpException>(() => client.Users.All());

--- a/src/Tests/IntegrationTests/SampleUserUsage.cs
+++ b/src/Tests/IntegrationTests/SampleUserUsage.cs
@@ -101,7 +101,7 @@ namespace TeamCitySharp.IntegrationTests
         [Ignore("Needs an enterprise license")]
         public void it_returns_all_user_roles_by_user_name()
         {
-            string userName = "teamcitysharpuser";
+            string userName = Configuration.GetAppSetting("NameOfUserWithRoles");
             List<Role> roles = m_client.Users.AllRolesByUserName(userName);
 
             Assert.That(roles.Any(), "No roles found for this user");
@@ -122,13 +122,13 @@ namespace TeamCitySharp.IntegrationTests
             string userName = m_username;
             User details = m_client.Users.Details(userName);
 
-            Assert.That(details.Email.ToLowerInvariant().Contains("@"), "Incorrect email address");
+            Assert.That(details.Email, Is.EqualTo(Configuration.GetAppSetting("UserEmail")), "Incorrect email address");
         }
 
         [Test]
         public void it_should_throw_exception_when_forbidden_status_code_returned()
         {
-            var client = new TeamCityClient(m_server, m_useSsl);
+            var client = new TeamCityClient(m_server, m_useSsl, Configuration.GetWireMockClient);
             client.ConnectAsGuest();
 
             Assert.Throws<HttpException>(() => client.Users.All());

--- a/src/Tests/IntegrationTests/SampleVcsUsage.cs
+++ b/src/Tests/IntegrationTests/SampleVcsUsage.cs
@@ -59,9 +59,10 @@ namespace TeamCitySharp.IntegrationTests
             Assert.That(vcsRoots.Any(), "No VCS Roots were found for the installation");
         }
 
-        [TestCase("TestDrive_ReactApp_HttpsGithubComHypnosphiTeamcityReactDemoRefsHeadsMaster")]
-        public void it_returns_vcs_details_when_passing_vcs_root_id(string vcsRootId)
+        [Test]
+        public void it_returns_vcs_details_when_passing_vcs_root_id()
         {
+            string vcsRootId = Configuration.GetAppSetting("IdOfVcsRoot");
             VcsRoot rootDetails = m_client.VcsRoots.ById(vcsRootId);
 
             Assert.That(rootDetails, Is.Not.Null, "Cannot find the specific VCSRoot");
@@ -119,7 +120,7 @@ namespace TeamCitySharp.IntegrationTests
         public void it_throws_exception_create_new_vsc_forbidden()
         {
             var client = new TeamCityClient(m_server, m_useSsl);
-            client.Connect(m_username, m_password);
+            client.Connect(Configuration.GetAppSetting("NonAdminUser"), m_password);
             var project = client.Projects.ById(m_goodProjectId);
 
             VcsRoot vcsroot = new VcsRoot();

--- a/src/Tests/IntegrationTests/appsettings.json
+++ b/src/Tests/IntegrationTests/appsettings.json
@@ -1,14 +1,35 @@
 {
-  "Server": "teamcity.jetbrains.com",
+  "Server": "teamcity.example.com",
   "UseSSL": "true",
-  "Username": "username",
-  "Password": "password",
-  "Token": "token",
-  "GoodBuildConfigId": "YouTrackSharp_ContinuousIntegration",
-  "GoodProjectId": "YouTrackSharp",
-  "GoodBuildId": "1299317",
-  "GoodTemplateId": "YouTrackSharpTemplate",
-  "GoodNumber": "",
-  "QueuedBuildConfigId": "bt864",
-  "QueuedProjectId": "R2rml4net"
+  "Username": "testing-teamcity-sharp-admin",
+  "NonAdminUser": "testing-tc-sharp-non-admin",
+  "Password": "secret-password",
+  "Token": "secret token for 'testing-teamcity-sharp-admin' user",
+  "GoodBuildConfigId": "TestingTeamCitySharp_ContinuousIntegration",
+  "GoodProjectId": "TestingTeamCitySharp",
+  "GoodTemplateId": "TestingTeamCitySharp_TestTemplate",
+  "QueuedBuildConfigId": "TestingTeamCitySharp_BuildThatNeverRuns",
+  "GoodTestId": "9197712699487599028",
+  "BuildWithTestsId": "2505",
+
+  "IdOfBuildConfigWithArtifactAndVcsRoot": "TestingTeamCitySharp_BuildWithVcsRoot",
+  "BranchNameForBuildConfigWithArtifactAndVcsRoot": "refs/heads/dependabot/nuget/Nuke.Common-9.0.3",
+  "ArtifactNameForBuildConfigWithArtifactAndVcsRoot": "Outputs.zip",
+
+  "IdOfBuildConfigWithArtifact": "TestingTeamCitySharp_ContinuousIntegration",
+  "ArtifactNameForBuildConfigWithArtifact": "Outputs.zip",
+
+  "IdOfProjectWithQueuedBuilds": "TestingTeamCitySharp",
+  "NameOfBuildConfigWithTests": "Build with tests",
+  "IdOfBuildConfigWithTests": "TestingTeamCitySharp_BuildWithTests",
+
+  "NameOfProjectWithBuildConfigs": "Testing TeamCitySharp",
+
+  "IdOfBuildWithSubsequentBuilds": "2505",
+  "NumberOfSubsequentBuilds": "4",
+  "BuildNumberOfBuildToPin": "3",
+  "NameOfUserWithRoles": "testing-tc-sharp",
+  "UserEmail": "testing-tc-sharp@example.com",
+  "IdOfVcsRoot": "TestingTeamCitySharp_VcsRootTeamCitySharp",
+  "NumberOfBranchesForBuildConfigWithArtifactAndVcsRoot": "4"
 }


### PR DESCRIPTION
Instead of hardcoding values in the integration tests, this PR moves them all to config, and tries to give them useful names.

This is a step on the journey to switching to wiremock.